### PR TITLE
Fix Node version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In this current version, the human player is RED, and the bot is BLUE. [A PDF wi
 
 ## To run locally
 
-`yarn && yarn start` - node, you must use Node v14. Not sure it why it doesn't run on v18.
+`yarn && yarn start` - node, you must use Node v14. Not sure why it doesn't run on v18.
 
 ## To Do / Someday
 


### PR DESCRIPTION
## Summary
- fix a small typo in the README about Node v18

## Testing
- `yarn test --watchAll=false` *(fails: package not present in lockfile)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e0fb51c832ab91de9ce4b1bf860

## Summary by Sourcery

Documentation:
- Correct grammatical error in Node v18 note in README