### PR TITLE
Update Node engine and TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In this current version, the human player is RED, and the bot is BLUE. [A PDF wi
 
 ## To run locally
 
-`yarn && yarn start` - node, you must use Node v14. Not sure it why it doesn't run on v18.
+`yarn && yarn start` - requires Node.js v18 or newer.
 
 ## To Do / Someday
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "^5.0.1",
+    "react-scripts": "5.0.1",
     "styled-components": "^6.1.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "web-vitals": "^2.1.0"
   },
   "engines": {
-    "node": "14.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -42,13 +42,13 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.16.4",
-    "@types/esm": "^3.2.0",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.13",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@types/esm": "^3.2.1",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@types/react-router-dom": "^5.3.3",
-    "@types/styled-components": "^5.1.25"
+    "@types/styled-components": "^5.1.26"
   }
 }


### PR DESCRIPTION
## Summary
- require Node.js 18 in engines field
- bump TypeScript and type definitions
- tweak README for Node 18

## Testing
- `yarn install --silent` *(fails: tunneling socket could not be established)*
- `yarn test --watchAll=false` *(fails: package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684027810b3c832abb1a261187e96072

## Summary by Sourcery

Require Node.js v18+, upgrade TypeScript and related type definitions, and update documentation to reflect the new engine requirement

Enhancements:
- Set engines.node to >=18.0.0
- Bump TypeScript from ^4.9.5 to ^5.2.2
- Upgrade React Scripts version specification and related dev dependency type definitions to latest versions

Documentation:
- Update README to require Node.js v18 or newer for local development