### PR TITLE
Fix typo in Node version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In this current version, the human player is RED, and the bot is BLUE. [A PDF wi
 
 ## To run locally
 
-`yarn && yarn start` - node, you must use Node v14. Not sure it why it doesn't run on v18.
+`yarn && yarn start` - node, you must use Node v14. Not sure why it doesn't run on v18.
 
 ## To Do / Someday
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct 'it why' to 'why' in the Node version requirement instruction.