### PR TITLE
Clarify queue size limit test case

### DIFF
--- a/src/game/entering-space.test.ts
+++ b/src/game/entering-space.test.ts
@@ -43,7 +43,7 @@ xdescribe('the queue', () => {
       expect(G.pieces[1].canMove).toBe(true);
     });
 
-    it('makes the rest of the rack pieces canMove: false when the queue size reaches its maximum of 3', () => {
+    it('prevents additional rack pieces from moving once the queue reaches its maximum size of 3', () => {
       [R0, R1, R2, R3].forEach((p) => G.pieces.push(p));
       ['r0', 'r1', 'r2'].forEach((id) => movePiece(G, _ctx, id));
       expect(G.pieces[0].canMove).toBe(false);

--- a/src/game/entering-space.test.ts
+++ b/src/game/entering-space.test.ts
@@ -43,7 +43,7 @@ xdescribe('the queue', () => {
       expect(G.pieces[1].canMove).toBe(true);
     });
 
-    it('makes the rest of the rack pieces canMove: false w/ queue size > 3', () => {
+    it('makes the rest of the rack pieces canMove: false when the queue size reaches its maximum of 3', () => {
       [R0, R1, R2, R3].forEach((p) => G.pieces.push(p));
       ['r0', 'r1', 'r2'].forEach((id) => movePiece(G, _ctx, id));
       expect(G.pieces[0].canMove).toBe(false);


### PR DESCRIPTION
## Summary
- adjust queue-size limit test wording

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e48ed2c832a90c653375eaf861a