### PR TITLE
Fix isPlayersTurn usage for queue moves

### DIFF
--- a/src/game/moves.ts
+++ b/src/game/moves.ts
@@ -70,7 +70,7 @@ export const toRack: Move<InputBoardGameState> = (
   const piece = getPieceFromId(G.pieces, pieceId);
   if (
     !piece ||
-    !isPlayersTurn(ctx.currentPlayer, ctx) ||
+    !isPlayersTurn(piece.color, ctx) ||
     piece.nextMove !== RACK
   ) {
     return INVALID_MOVE;
@@ -89,7 +89,7 @@ export const toEnteringSpace: Move<InputBoardGameState> = (
   const piece = getPieceFromId(G.pieces, pieceId);
   if (
     !piece ||
-    !isPlayersTurn(ctx.currentPlayer, ctx) ||
+    !isPlayersTurn(piece.color, ctx) ||
     piece.nextMove !== RACK
   ) {
     return INVALID_MOVE;


### PR DESCRIPTION
## Summary
- ensure toRack/toEnteringSpace validate the active player

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e341c8c832ab85dfb7669d83b03